### PR TITLE
fix request matcher not working for GET /api/genre

### DIFF
--- a/src/main/java/com/revature/config/WebSecurityConfig.java
+++ b/src/main/java/com/revature/config/WebSecurityConfig.java
@@ -42,7 +42,7 @@ public class WebSecurityConfig {
                 .requestCache(RequestCacheConfigurer::disable)
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers("/auth/*").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/genre/*", "/api/movie/*").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/genre/**", "/api/movie/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/genre", "/api/movie").hasRole("ADMIN")
                         .requestMatchers(toH2Console()).permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
Requestmatcher was working for GET /api/genre/{id} and GET /api/movie/{id}, but not for list endpoints GET /api/genre and GET /api/movie.