### PR TITLE
OPTIONS needs to have the same authorization as GET for the frontend …

### DIFF
--- a/src/main/java/com/revature/config/WebSecurityConfig.java
+++ b/src/main/java/com/revature/config/WebSecurityConfig.java
@@ -43,6 +43,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers("/auth/*").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/genre/**", "/api/movie/**").permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/api/genre/**", "/api/movie/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/genre", "/api/movie").hasRole("ADMIN")
                         .requestMatchers(toH2Console()).permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
CORS not working because OPTIONS /api/genre is not allowed
Something on the frontend is sending the OPTIONS request before actually sending the GET request.

Here is more on [why the OPTIONS HTTP method request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) is sent.